### PR TITLE
Removes 411 status code for POST requests with an empty body.

### DIFF
--- a/src/System/Net/HttpListener.cs
+++ b/src/System/Net/HttpListener.cs
@@ -38,28 +38,17 @@ namespace SpaceWizards.HttpListener
             _internalLock = new object();
             _defaultServiceNames = new ServiceNameStore();
 
-            _certificate = certificate;
             _timeoutManager = new HttpListenerTimeoutManager(this);
             _prefixes = new HttpListenerPrefixCollection(this);
 
             // default: no CBT checks on any platform (appcompat reasons); applies also to PolicyEnforcement
             // config element
             _extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Never);
-        }
 
-        public HttpListener(string certPemFilePath, string? keyPemFilePath = default)
-        {
-            _state = State.Stopped;
-            _internalLock = new object();
-            _defaultServiceNames = new ServiceNameStore();
-
-            _certificate = X509Certificate2.CreateFromPemFile(certPemFilePath, keyPemFilePath);
-            _timeoutManager = new HttpListenerTimeoutManager(this);
-            _prefixes = new HttpListenerPrefixCollection(this);
-
-            // default: no CBT checks on any platform (appcompat reasons); applies also to PolicyEnforcement
-            // config element
-            _extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Never);
+            if (certificate != null)
+            {
+                SetCertificate(certificate);
+            }
         }
 
         public AuthenticationSchemeSelector? AuthenticationSchemeSelectorDelegate
@@ -276,6 +265,11 @@ namespace SpaceWizards.HttpListener
                 (callback, state) => ((HttpListener)state!).BeginGetContext(callback, state),
                 iar => ((HttpListener)iar!.AsyncState!).EndGetContext(iar),
                 this);
+        }
+
+        public void SetCertificate(X509Certificate2 certificate)
+        {
+            _certificate = certificate;
         }
 
         public void Close()

--- a/src/System/Net/HttpListener.cs
+++ b/src/System/Net/HttpListener.cs
@@ -32,7 +32,7 @@ namespace SpaceWizards.HttpListener
 
         internal ICollection PrefixCollection => _uriPrefixes.Keys;
 
-        public HttpListener(X509Certificate2? certificate = null)
+        public HttpListener()
         {
             _state = State.Stopped;
             _internalLock = new object();
@@ -44,11 +44,6 @@ namespace SpaceWizards.HttpListener
             // default: no CBT checks on any platform (appcompat reasons); applies also to PolicyEnforcement
             // config element
             _extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Never);
-
-            if (certificate != null)
-            {
-                SetCertificate(certificate);
-            }
         }
 
         public AuthenticationSchemeSelector? AuthenticationSchemeSelectorDelegate

--- a/src/System/Net/Managed/HttpConnection.cs
+++ b/src/System/Net/Managed/HttpConnection.cs
@@ -80,10 +80,8 @@ namespace SpaceWizards.HttpListener
             _epl = epl;
             _secure = secure;
             _cert = cert;
-            if (secure == false)
-            {
+            if (!secure)
                 _stream = new NetworkStream(sock, false);
-            }
             else
             {
 #pragma warning disable CA5359
@@ -94,11 +92,8 @@ namespace SpaceWizards.HttpListener
                         return true;
                     }
 
-                    var c2 = c as X509Certificate2;
-                    if (c2 == null)
-                    {
-                        c2 = new X509Certificate2(c.GetRawCertData());
-                    }
+                    X509Certificate2? c2 = c as X509Certificate2;
+                    c2 ??= new X509Certificate2(c.GetRawCertData());
 
                     _clientCert = c2;
                     _clientCertErrors = new int[] { (int)e };
@@ -110,9 +105,7 @@ namespace SpaceWizards.HttpListener
             }
 
             _timer = new Timer(OnTimeout, null, Timeout.Infinite, Timeout.Infinite);
-            if (_sslStream != null) {
-                _sslStream.AuthenticateAsServer (_cert, true, (SslProtocols)ServicePointManager.SecurityProtocol, false);
-            }
+            _sslStream?.AuthenticateAsServer(_cert, false, (SslProtocols)ServicePointManager.SecurityProtocol, false);
             Init();
         }
 

--- a/src/System/Net/Managed/HttpConnection.cs
+++ b/src/System/Net/Managed/HttpConnection.cs
@@ -80,8 +80,10 @@ namespace SpaceWizards.HttpListener
             _epl = epl;
             _secure = secure;
             _cert = cert;
-            if (!secure)
+            if (secure == false)
+            {
                 _stream = new NetworkStream(sock, false);
+            }
             else
             {
 #pragma warning disable CA5359

--- a/src/System/Net/Managed/HttpListener.Certificates.cs
+++ b/src/System/Net/Managed/HttpListener.Certificates.cs
@@ -19,8 +19,7 @@ namespace SpaceWizards.HttpListener
 
         internal X509Certificate? LoadCertificateAndKey(IPAddress addr, int port)
         {
-            // TODO https://github.com/dotnet/runtime/issues/19752: Implement functionality to read SSL certificate.
-            return null;
+            return _certificate;
         }
     }
 }

--- a/src/System/Net/Managed/HttpListenerRequest.Managed.cs
+++ b/src/System/Net/Managed/HttpListenerRequest.Managed.cs
@@ -221,12 +221,15 @@ namespace SpaceWizards.HttpListener
 
             if (!_isChunked && !_clSet)
             {
-                if (string.Equals(_method, "POST", StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(_method, "PUT", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(_method, "PUT", StringComparison.OrdinalIgnoreCase))
                 {
                     _context.ErrorStatus = 411;
                     _context.ErrorMessage = "";
                     return;
+                }
+                else if (string.Equals(_method, "POST", StringComparison.OrdinalIgnoreCase))
+                {
+                    _contentLength = 0; // for safety we explicitly set it to 0.
                 }
             }
 


### PR DESCRIPTION
Removes 411 status code for POST requests with an empty body.

This seems dumb, but some systems does that, and it's a mistake to not let them do their weird requests.

An example would be the SVO (Sports View Online) server used in some PlayStation games which sends a POST request with nothing inside.