### PR TITLE
Removes 411 status code for POST requests with an empty body.

### DIFF
--- a/src/System/Net/Managed/HttpListenerRequest.Managed.cs
+++ b/src/System/Net/Managed/HttpListenerRequest.Managed.cs
@@ -221,12 +221,15 @@ namespace SpaceWizards.HttpListener
 
             if (!_isChunked && !_clSet)
             {
-                if (string.Equals(_method, "POST", StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(_method, "PUT", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(_method, "PUT", StringComparison.OrdinalIgnoreCase))
                 {
                     _context.ErrorStatus = 411;
                     _context.ErrorMessage = "";
                     return;
+                }
+                else if (string.Equals(_method, "POST", StringComparison.OrdinalIgnoreCase))
+                {
+                    _contentLength = 0; // for safety we explicitly set it to 0.
                 }
             }
 


### PR DESCRIPTION
Removes 411 status code for POST requests with an empty body.

This seems dumb, but some systems does that, and it's a mistake to not let them do their weird requests.

An example would be the SVO (Sports View Online) server used in some PlayStation games which sends a POST request with nothing inside.