### PR TITLE
Implements back the port based SSL certificate fetching + real SNI support.

### DIFF
--- a/src/SpaceWizards.HttpListener.csproj
+++ b/src/SpaceWizards.HttpListener.csproj
@@ -84,6 +84,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="SR.cs" />
+    <Compile Include="System\Net\CertificateHelper.cs" />
     <Compile Include="System\Net\StreamHelper.cs" />
   </ItemGroup>
 </Project>

--- a/src/System/Net/CertificateHelper.cs
+++ b/src/System/Net/CertificateHelper.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography;
+using System.Collections.Concurrent;
+using System.Net;
+
+namespace SpaceWizards.HttpListener
+{
+    public class CertificateHelper
+    {
+        private static readonly string[] tlds = {
+            ".com", ".org", ".net", ".int", ".edu", ".gov", ".mil", // Generic TLDs
+            ".info", ".biz", ".mobi", ".name", ".pro", ".aero", ".coop", // Generic TLDs continued
+            ".asia", ".cat", ".jobs", ".museum", ".tel", ".travel", ".tel", // Sponsored TLDs
+            ".travel", ".int", ".online",
+            ".ac", ".ad", ".ae", ".af", ".ag", ".ai", ".al", ".am", ".an", // Country Code TLDs (A-Z)
+            ".ao", ".aq", ".ar", ".as", ".at", ".au", ".aw", ".ax", ".az",
+            ".ba", ".bb", ".bd", ".be", ".bf", ".bg", ".bh", ".bi", ".bj",
+            ".bm", ".bn", ".bo", ".br", ".bs", ".bt", ".bv", ".bw", ".by",
+            ".bz", ".ca", ".cc", ".cd", ".cf", ".cg", ".ch", ".ci", ".ck",
+            ".cl", ".cm", ".cn", ".co", ".cr", ".cs", ".cu", ".cv", ".cx",
+            ".cy", ".cz", ".dd", ".de", ".dj", ".dk", ".dm", ".do", ".dz",
+            ".ec", ".ee", ".eg", ".eh", ".er", ".es", ".et", ".eu", ".fi",
+            ".fj", ".fk", ".fm", ".fo", ".fr", ".ga", ".gb", ".gd", ".ge",
+            ".gf", ".gg", ".gh", ".gi", ".gl", ".gm", ".gn", ".gp", ".gq",
+            ".gr", ".gs", ".gt", ".gu", ".gw", ".gy", ".hk", ".hm", ".hn",
+            ".hr", ".ht", ".hu", ".id", ".ie", ".il", ".im", ".in", ".io",
+            ".iq", ".ir", ".is",".it", ".je", ".jm", ".jo", ".jp", ".ke",
+            ".kg", ".kh", ".ki", ".km", ".kn", ".kp", ".kr", ".kw", ".ky",
+            ".kz", ".la", ".lb", ".lc", ".li", ".lk", ".lr", ".ls", ".lt",
+            ".lu", ".lv", ".ly", ".ma", ".mc", ".md", ".me", ".mg", ".mh",
+            ".mk", ".ml", ".mm", ".mn", ".mo", ".mp", ".mq", ".mr", ".ms",
+            ".mt", ".mu", ".mv", ".mw", ".mx", ".my", ".mz", ".na", ".nc",
+            ".ne", ".nf", ".ng", ".ni", ".nl", ".no", ".np",  ".nr", ".nu",
+            ".nz", ".om", ".pa", ".pe", ".pf", ".pg", ".ph", ".pk", ".pl",
+            ".pm", ".pn", ".pr", ".ps", ".pt", ".pw", ".py", ".qa", ".re",
+            ".ro", ".rs", ".ru", ".rw", ".sa", ".sb", ".sc", ".sd", ".se",
+            ".sg", ".sh", ".si", ".sj", ".sk", ".sl", ".sm", ".sn", ".so",
+            ".sr", ".ss", ".st", ".su",  ".sv", ".sx", ".sy", ".sz", ".tc",
+            ".td", ".tf", ".tg", ".th", ".tj", ".tk", ".tl", ".tm", ".tn",
+            ".to", ".tp", ".tr", ".tt", ".tv", ".tw", ".tz",  ".ua", ".ug",
+            ".uk", ".us", ".uy", ".uz",  ".va", ".vc", ".ve", ".vg", ".vi",
+            ".vn", ".vu", ".wf", ".ws", ".ye", ".yt", ".za", ".zm", ".zw",
+            ".arpa", ".aero", ".coop", ".museum", ".asia", ".cat", ".jobs", // Infrastructure TLD
+            ".mobi",
+            ".example", ".localhost", ".test" // Reserved TLDs
+        };
+
+        private static ConcurrentDictionary<string, X509Certificate2> FakeCertificates = new ConcurrentDictionary<string, X509Certificate2>();
+
+        /// <summary>
+        /// Issue a chain-signed SSL certificate with private key.
+        /// </summary>
+        /// <param name="certSubject">Certificate subject (domain name).</param>
+        /// <param name="issuerCertificate">Authority's certificate used to sign this certificate.</param>
+        /// <param name="serverIp">IP Address of the remote server.</param>
+        /// <param name="certHashAlgorithm">Certificate hash algorithm.</param>
+        /// <param name="certVaildBeforeNow">Minimum Certificate validity Date.</param>
+        /// <param name="certVaildAfterNow">Maximum Certificate validity Date.</param>
+        /// <param name="wildcard">(optional) Enables wildcard SAN attributes.</param>
+        /// <returns>Signed chain of SSL Certificates.</returns>
+        public static X509Certificate MakeChainSignedCert(string certSubject, X509Certificate2 issuerCertificate, HashAlgorithmName certHashAlgorithm,
+            IPAddress serverIp, DateTimeOffset certVaildBeforeNow, DateTimeOffset certVaildAfterNow, bool wildcard = false)
+        {
+            // Look if it is already issued.
+            // Why: https://support.mozilla.org/en-US/kb/Certificate-contains-the-same-serial-number-as-another-certificate
+            if (FakeCertificates.ContainsKey(certSubject))
+            {
+                X509Certificate2 CachedCertificate = FakeCertificates[certSubject];
+                //check that it hasn't expired
+                if (CachedCertificate.NotAfter > DateTime.Now && CachedCertificate.NotBefore < DateTime.Now)
+                { return CachedCertificate; }
+                else
+                { FakeCertificates.Remove(certSubject, out _); }
+            }
+
+            using RSA issuerPrivKey = issuerCertificate.GetRSAPrivateKey() ?? throw new Exception("Issuer Certificate doesn't have a private key, Chain Signed Certificate will not be generated.");
+
+            // If not found, initialize private key generator & set up a certificate creation request.
+            using RSA rsa = RSA.Create();
+
+            // Generate an unique serial number.
+            byte[] certSerialNumber = new byte[16];
+            new Random().NextBytes(certSerialNumber);
+
+            // set up a certificate creation request.
+            CertificateRequest certRequestAny = new CertificateRequest($"CN={certSubject} [{GetRandomInt64(100, 999)}], OU=SpaceStation14 Department," +
+                $" O=\"SpaceWizards Corp\", L=New York, S=Northeastern United, C=US", rsa, certHashAlgorithm, RSASignaturePadding.Pkcs1);
+
+            // set up a optional SAN builder.
+            SubjectAlternativeNameBuilder sanBuilder = new SubjectAlternativeNameBuilder();
+
+            sanBuilder.AddDnsName(certSubject); // Some legacy clients will not recognize the cert serial-number.
+            sanBuilder.AddEmailAddress("SpaceWizards@gmail.com");
+            sanBuilder.AddIpAddress(serverIp);
+
+            if (wildcard)
+            {
+                tlds.Select(tld => "*" + tld)
+                .ToList()
+                .ForEach(sanBuilder.AddDnsName);
+            }
+
+            certRequestAny.CertificateExtensions.Add(sanBuilder.Build());
+
+            // Export the issued certificate with private key.
+            X509Certificate2 certificateWithKey = new X509Certificate2(certRequestAny.Create(
+                issuerCertificate.IssuerName,
+                new RsaPkcs1SignatureGenerator(issuerPrivKey),
+                certVaildBeforeNow,
+                certVaildAfterNow,
+                certSerialNumber).CopyWithPrivateKey(rsa).Export(X509ContentType.Pfx));
+
+            // Save the certificate and return it.
+            FakeCertificates.TryAdd(certSubject, certificateWithKey);
+            return certificateWithKey;
+        }
+
+        /// <summary>
+        /// Checks if the X509Certificate is of Certificate Authority type.
+        /// </summary>
+        /// <param name="certificate">The certificate to check on.</param>
+        /// <returns>A bool.</returns>
+        public static bool IsCertificateAuthority(X509Certificate certificate)
+        {
+            // Compare the Issuer and Subject properties of the certificate
+            return certificate.Issuer == certificate.Subject;
+        }
+
+
+        /// <summary>
+        /// Get a random int64 number.
+        /// </summary>
+        /// <param name="minValue">The min value.</param>
+        /// <param name="maxValue">The max value.</param>
+        /// <returns>A long.</returns>
+        private static long GetRandomInt64(long minValue, long maxValue)
+        {
+#if NET6_0_OR_GREATER
+            return new Random().NextInt64(minValue, maxValue);
+#else
+            Random random = new Random();
+            return (long)(((random.Next() << 32) | random.Next()) * (double)(maxValue - minValue) / 0xFFFFFFFFFFFFFFFF) + minValue;
+#endif
+        }
+    }
+
+    /// <summary>
+	/// RSA-MD5, RSA-SHA1, RSA-SHA256, RSA-SHA512 signature generator for X509 certificates.
+	/// </summary>
+	sealed class RsaPkcs1SignatureGenerator : X509SignatureGenerator
+    {
+        // Workaround for SHA1 and MD5 ban in .NET 4.7.2 and .NET Core.
+        // Ideas used from:
+        // https://stackoverflow.com/a/59989889/7600726
+        // https://github.com/dotnet/corefx/pull/18344/files/c74f630f38b6f29142c8dc73623fdcb4f7905f87#r112066147
+        // https://github.com/dotnet/corefx/blob/5fe5f9aae7b2987adc7082f90712b265bee5eefc/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/PrivateKeyAssociationTests.cs#L531-L553
+        // https://github.com/dotnet/runtime/blob/89f3a9ef41383bb409b69d1a0f0db910f3ed9a34/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/X509Sha1SignatureGenerators.cs#LL31C38-L31C38
+
+        private readonly X509SignatureGenerator _realRsaGenerator;
+
+        internal RsaPkcs1SignatureGenerator(RSA rsa)
+        {
+            _realRsaGenerator = CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
+        }
+
+        protected override PublicKey BuildPublicKey() => _realRsaGenerator.PublicKey;
+
+        /// <summary>
+        /// Callback for .NET signing functions.
+        /// </summary>
+        /// <param name="hashAlgorithm">Hashing algorithm name.</param>
+        /// <returns>Hashing algorithm ID in some correct format.</returns>
+        public override byte[] GetSignatureAlgorithmIdentifier(HashAlgorithmName hashAlgorithm)
+        {
+            /*
+			 * https://bugzilla.mozilla.org/show_bug.cgi?id=1064636#c28
+				300d06092a864886f70d0101020500  :md2WithRSAEncryption           1
+				300b06092a864886f70d01010b      :sha256WithRSAEncryption        2
+				300b06092a864886f70d010105      :sha1WithRSAEncryption          1
+				300d06092a864886f70d01010c0500  :sha384WithRSAEncryption        20
+				300a06082a8648ce3d040303        :ecdsa-with-SHA384              20
+				300a06082a8648ce3d040302        :ecdsa-with-SHA256              97
+				300d06092a864886f70d0101040500  :md5WithRSAEncryption           6512
+				300d06092a864886f70d01010d0500  :sha512WithRSAEncryption        7715
+				300d06092a864886f70d01010b0500  :sha256WithRSAEncryption        483338
+				300d06092a864886f70d0101050500  :sha1WithRSAEncryption          4498605
+			 */
+            const string MD5id = "300D06092A864886F70D0101040500";
+            const string SHA1id = "300D06092A864886F70D0101050500";
+            const string SHA256id = "300D06092A864886F70D01010B0500";
+            const string SHA384id = "300D06092A864886F70D01010C0500"; //?
+            const string SHA512id = "300D06092A864886F70D01010D0500";
+
+            if (hashAlgorithm == HashAlgorithmName.MD5)
+                return HexToByteArray(MD5id);
+            if (hashAlgorithm == HashAlgorithmName.SHA1)
+                return HexToByteArray(SHA1id);
+            if (hashAlgorithm == HashAlgorithmName.SHA256)
+                return HexToByteArray(SHA256id);
+            if (hashAlgorithm == HashAlgorithmName.SHA384)
+                return HexToByteArray(SHA384id);
+            if (hashAlgorithm == HashAlgorithmName.SHA512)
+                return HexToByteArray(SHA512id);
+
+            throw new ArgumentOutOfRangeException(nameof(hashAlgorithm), "'" + hashAlgorithm + "' is not a supported algorithm at this moment.");
+        }
+
+        /// <summary>
+        /// Convert a hex-formatted string to byte array.
+        /// </summary>
+        /// <param name="hex">A string looking like "300D06092A864886F70D0101050500".</param>
+        /// <returns>A byte array.</returns>
+        public static byte[] HexToByteArray(string hex)
+        {
+            //copypasted from:
+            //https://social.msdn.microsoft.com/Forums/en-US/851492fa-9ddb-42d7-8d9a-13d5e12fdc70/convert-from-a-hex-string-to-a-byte-array-in-c?forum=aspgettingstarted
+            return Enumerable.Range(0, hex.Length)
+                             .Where(x => x % 2 == 0)
+                             .Select(x => Convert.ToByte(hex.Substring(x, 2), 16))
+                             .ToArray();
+        }
+
+        /// <summary>
+        /// Sign specified <paramref name="data"/> using specified <paramref name="hashAlgorithm"/>.
+        /// </summary>
+        /// <returns>X.509 signature for specified data.</returns>
+        public override byte[] SignData(byte[] data, HashAlgorithmName hashAlgorithm) =>
+            _realRsaGenerator.SignData(data, hashAlgorithm);
+    }
+}

--- a/src/System/Net/Managed/HttpConnection.cs
+++ b/src/System/Net/Managed/HttpConnection.cs
@@ -62,19 +62,37 @@ namespace SpaceWizards.HttpListener
         private int _reuses;
         private bool _contextBound;
         private bool _secure;
-        private X509Certificate _cert;
+        private X509Certificate2 _cert;
         private int _timeout = 90000; // 90k ms for first request, 15k ms from then on
         private Timer _timer;
         private IPEndPoint? _localEndPoint;
         private HttpListener? _lastListener;
         private int[]? _clientCertErrors;
         private X509Certificate2? _clientCert;
+        private string? _sniDomain;
         private SslStream? _sslStream;
         private InputState _inputState = InputState.RequestLine;
         private LineState _lineState = LineState.None;
         private int _position;
 
-        public HttpConnection(Socket sock, HttpEndPointListener epl, bool secure, X509Certificate cert)
+        internal static SslProtocols GetSslProtocol
+        {
+            get
+            {
+#pragma warning disable
+                SslProtocols protocols = SslProtocols.Default | SslProtocols.Tls11 | SslProtocols.Tls12;
+#pragma warning restore
+
+#if NET5_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
+
+                protocols |= SslProtocols.Tls13;
+#endif
+
+                return protocols;
+            }
+        }
+
+        public HttpConnection(Socket sock, HttpEndPointListener epl, bool secure, X509Certificate2 cert)
         {
             _socket = sock;
             _epl = epl;
@@ -107,7 +125,37 @@ namespace SpaceWizards.HttpListener
             }
 
             _timer = new Timer(OnTimeout, null, Timeout.Infinite, Timeout.Infinite);
-            _sslStream?.AuthenticateAsServer(_cert, false, (SslProtocols)ServicePointManager.SecurityProtocol, false);
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+            if (CertificateHelper.IsCertificateAuthority(_cert))
+            {
+                _sslStream?.AuthenticateAsServer(new SslServerAuthenticationOptions
+                {
+                    ClientCertificateRequired = false,
+                    EnabledSslProtocols = GetSslProtocol,
+                    CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
+                    ServerCertificateSelectionCallback = (sender, actualHostName) =>
+                    {
+                        if (string.IsNullOrEmpty(actualHostName))
+                        {
+                            _sniDomain = ((IPEndPoint?)sock.LocalEndPoint)?.Address.ToString() ?? "127.0.0.1";
+                        }
+                        else
+                        {
+                            _sniDomain = actualHostName;
+                        }
+                        return CertificateHelper.MakeChainSignedCert(_sniDomain, _cert, epl.Listener.GetPreferedHashAlgorithm(),
+                        ((IPEndPoint?)sock.RemoteEndPoint)?.Address ?? IPAddress.Any, DateTimeOffset.Now.AddDays(-1), DateTimeOffset.Now.AddDays(7),
+                        epl.Listener.wildcardCertificates);
+                    }
+                });
+            }
+            else
+            {
+                _sslStream?.AuthenticateAsServer(_cert, false, GetSslProtocol, false);
+            }
+#else
+            _sslStream?.AuthenticateAsServer(_cert, false, GetSslProtocol, false);
+#endif
             Init();
         }
 

--- a/src/System/Net/Managed/HttpConnection.cs
+++ b/src/System/Net/Managed/HttpConnection.cs
@@ -126,9 +126,9 @@ namespace SpaceWizards.HttpListener
 
             _timer = new Timer(OnTimeout, null, Timeout.Infinite, Timeout.Infinite);
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-            if (CertificateHelper.IsCertificateAuthority(_cert))
+            if (_sslStream != null && CertificateHelper.IsCertificateAuthority(_cert))
             {
-                _sslStream?.AuthenticateAsServer(new SslServerAuthenticationOptions
+                _sslStream.AuthenticateAsServer(new SslServerAuthenticationOptions
                 {
                     ClientCertificateRequired = false,
                     EnabledSslProtocols = GetSslProtocol,

--- a/src/System/Net/Managed/HttpEndPointListener.cs
+++ b/src/System/Net/Managed/HttpEndPointListener.cs
@@ -61,7 +61,7 @@ namespace SpaceWizards.HttpListener
             if (secure)
             {
                 _secure = secure;
-                _cert = _listener.LoadCertificateAndKey (addr, port);
+                _cert = _listener.LoadCertificateAndKey(addr, port);
             }
 
             _endpoint = new IPEndPoint(addr, port);

--- a/src/System/Net/Managed/HttpEndPointListener.cs
+++ b/src/System/Net/Managed/HttpEndPointListener.cs
@@ -48,7 +48,7 @@ namespace SpaceWizards.HttpListener
         private Dictionary<ListenerPrefix, HttpListener> _prefixes;
         private List<ListenerPrefix>? _unhandledPrefixes; // host = '*'
         private List<ListenerPrefix>? _allPrefixes;       // host = '+'
-        private X509Certificate? _cert;
+        private X509Certificate2? _cert;
         private bool _secure;
 
         public HttpEndPointListener(HttpListener listener, IPAddress addr, int port, bool secure)

--- a/src/System/Net/Managed/HttpListener.Certificates.cs
+++ b/src/System/Net/Managed/HttpListener.Certificates.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -19,7 +20,36 @@ namespace SpaceWizards.HttpListener
 
         internal X509Certificate? LoadCertificateAndKey(IPAddress addr, int port)
         {
-            return _certificate;
+            lock (_internalLock)
+            {
+                // Actually load the certificate
+                try
+                {
+                    if (_certificateCache != null && _certificateCache.TryGetValue(port, out X509Certificate2? certificate))
+                    {
+                        return certificate;
+                    }
+
+                    string path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ".mono");
+                    path = Path.Combine(path, "httplistener");
+                    string cert_file = Path.Combine(path, String.Format("{0}.pfx", port));
+                    if (File.Exists(cert_file))
+                    {
+                        string pass_file = Path.Combine(path, String.Format("{0}.password.txt", port));
+                        if (File.Exists(pass_file))
+                        {
+                            return new X509Certificate2(cert_file, File.ReadAllText(pass_file));
+                        }
+                        return new X509Certificate2(cert_file);
+                    }
+                }
+                catch
+                {
+                    // ignore errors
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/System/Net/Managed/HttpListener.Certificates.cs
+++ b/src/System/Net/Managed/HttpListener.Certificates.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Security;
@@ -18,7 +16,7 @@ namespace SpaceWizards.HttpListener
             return new SslStream(innerStream, ownsStream, callback);
         }
 
-        internal X509Certificate? LoadCertificateAndKey(IPAddress addr, int port)
+        internal X509Certificate2? LoadCertificateAndKey(IPAddress addr, int port)
         {
             lock (_internalLock)
             {

--- a/src/System/Net/Managed/HttpListenerRequest.Managed.cs
+++ b/src/System/Net/Managed/HttpListenerRequest.Managed.cs
@@ -197,7 +197,7 @@ namespace SpaceWizards.HttpListener
 
             string base_uri = $"{RequestScheme}://{host}:{LocalEndPoint!.Port}";
 
-            if (!Uri.TryCreate(base_uri + path, UriKind.Absolute, out _requestUri))
+            if (!Uri.TryCreate(base_uri + path, UriKind.Absolute, out _requestUri) || string.IsNullOrEmpty(_rawUrl))
             {
                 _context.ErrorMessage = WebUtility.HtmlEncode("Invalid url: " + base_uri + path);
                 return;


### PR DESCRIPTION
Implements back the port based SSL certificate fetching.

This modernize the Mono code base to allow booth, a in-memory cache and that same file-based cache if the in-memory cache doesn't contain the entry.

This makes the previous SetCertificate constructor obsolete, but for good, since we can now set a different certificate per ports.

This is not SNI level, but it's still leagues beyond the actual .NET implementation (the MYSTICAL null stubbed return value with the TODO ^^).